### PR TITLE
SigOpt_sklearn incompatible with scikit-learn 0.21

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from sigopt_sklearn.version import VERSION
 install_requires = [
   'joblib>=0.9.4',
   'numpy>=1.9',
-  'scikit-learn>=0.19',
+  'scikit-learn>=0.19,<0.21',
   'sigopt>=2.6.0',
 ]
 


### PR DESCRIPTION
To reproduce:

```bash
pip install sigopt_sklearn
pip install sigopt_sklearn[ensemble]
pip uninstall scikit-learn
pip install "scikit-learn>=0.21"
```
Then, run ensemble example: https://app.sigopt.com/docs/overview/scikit_learn

Observe that fit_params has been removed as an argument to BaseSearchCV in sklearn version 0.21

Also note that it appears our current version of this library also requires versions more recent than 0.17. Versions 0.17 and 0.18 ran into errors of missing libraries, as well.