### PR TITLE
Fix broken build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ cache:
   pip: true
 
 env:
-  - SKLEARN_VERSION=0.17.1
-  - SKLEARN_VERSION=0.18.2
   - SKLEARN_VERSION=0.19.2
   - SKLEARN_VERSION=0.20.0
 

--- a/lint
+++ b/lint
@@ -28,6 +28,7 @@ pylint sigopt_sklearn \
   -d locally-disabled \
   -d locally-enabled \
   -d missing-docstring \
+  -d no-else-raise \
   -d no-init \
   -d no-self-use \
   -d no-value-for-parameter \

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
   packages=['sigopt_sklearn'],
   install_requires=install_requires,
   extras_require={
-    'ensemble': ['xgboost>=0.4a30'],
+    'ensemble': ['xgboost>=0.4a30,<0.90'],
   },
   classifiers=[
     "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from sigopt_sklearn.version import VERSION
 install_requires = [
   'joblib>=0.9.4',
   'numpy>=1.9',
-  'scikit-learn>=0.17.1',
+  'scikit-learn>=0.19',
   'sigopt>=2.6.0',
 ]
 


### PR DESCRIPTION
Last passing test was January 31, 2019. Unfortunately, re-running it causes the build to fail, most likely due to changing underlying dependencies.

Now tests break with an xgboost error. Since January 31, 2019, versions 0.82 and 0.90 have been released, so try walking back until we see passing tests