### PR TITLE
readme-fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ def load_datafile(filename):
   X = []
   with open(filename, 'r') as f:
     for l in f:
-      X.append(numpy.array([float(v) for v in l.split()]))
+      X.append(np.array([float(v) for v in l.split()]))
   X = np.vstack(X)
   return X
 


### PR DESCRIPTION
tried copy-pasting code, and we `import numpy as np` at the top of this snippet